### PR TITLE
fix (anvil): error E0063 when compile on macOS

### DIFF
--- a/crates/anvil/src/eth/api.rs
+++ b/crates/anvil/src/eth/api.rs
@@ -1312,7 +1312,9 @@ impl EthApi {
         let mut response = FeeHistory {
             oldest_block: U256::from(lowest),
             base_fee_per_gas: Vec::new(),
+            base_fee_per_blob_gas: Vec::new(),
             gas_used_ratio: Vec::new(),
+            blob_gas_used_ratio: Vec::new(),
             reward: Some(Default::default()),
         };
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Using macOS with rust version `rustc 1.75.0 (82e1608df 2023-12-21)` compiles anvil will throw error of E0063 as below:
```bash
   Compiling anvil v0.2.0 (/Users/benji/Develop/blockchain/foundry/crates/anvil)
error[E0063]: missing fields `base_fee_per_blob_gas` and `blob_gas_used_ratio` in initializer of `alloy_rpc_types::FeeHistory`
    --> crates/anvil/src/eth/api.rs:1312:28
     |
1312 |         let mut response = FeeHistory {
     |                            ^^^^^^^^^^ missing `base_fee_per_blob_gas` and `blob_gas_used_ratio`

For more information about this error, try `rustc --explain E0063`.
error: could not compile `anvil` (lib) due to previous error
```



## Solution
Modify `api.rc:1317` `let mut FeeHistory` to hotfix the bug. After successfully compiling, I cannot find any further bug caused by this modification that will make Anvil malfunction.

```
        let mut response = FeeHistory {
            oldest_block: U256::from(lowest),
            base_fee_per_gas: Vec::new(),
            base_fee_per_blob_gas: Vec::new(),
            gas_used_ratio: Vec::new(),
            blob_gas_used_ratio: Vec::new(),
            reward: Some(Default::default()),
        };
```

However, the IDE will prompt that these two members of the struct do not exist in alloy_rpc_types::FeeHistory

